### PR TITLE
Add service: Recommendations via Google Sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This project integrates the following Google products/services:
 | Management Tools | Google Stackdriver Error Reporting | Error identification and reporting tool |
 | Developer Tools | Google Cloud Build | CI/CD solution |
 | Smart Home | Google Assistant | AI-powered virtual assistant |
+| Business & Collaboration | Google Sheets | Collaborative, extensible online spreadsheets for home and enterprise users. |
 
 ## Architecture Overview
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -56,3 +56,7 @@ steps:
 # images.
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ['functions', 'deploy', 'upload_image', '--source=./functions/upload_image/', '--runtime=python37', '--trigger-http', '--env-vars-file=./extras/cloudbuild/functions_env_vars.yaml']
+# Cloud Build Step #11: Deploy the Cloud Function for recommendations.
+# images.
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: ['functions', 'deploy', 'recommendation', '--source=./functions/recommendation/', '--runtime=nodejs8', '--trigger-http']

--- a/functions/recommendation/.eslintrc.yml
+++ b/functions/recommendation/.eslintrc.yml
@@ -1,0 +1,11 @@
+env:
+  browser: true
+  commonjs: true
+  es6: true
+extends: google
+globals:
+  Atomics: readonly
+  SharedArrayBuffer: readonly
+parserOptions:
+  ecmaVersion: 2018
+rules: {}

--- a/functions/recommendation/.gitignore
+++ b/functions/recommendation/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/functions/recommendation/README.md
+++ b/functions/recommendation/README.md
@@ -1,0 +1,61 @@
+# Recommendation Service
+
+The recommendation service provides a simple API to retrieve a list of recommended products
+based on recommendations manually configured via a Google Sheet.
+
+## Usage
+
+### Request
+
+The productID querystring parameter expects a list of products using querystring array notation.
+
+```
+GET https://[CLOUD_FUNCTION_DOMAIN]/recommend?productId[]=blanket&productId[]=shoe
+```
+
+### Response: Success (200 OK)
+
+```
+{
+  "data": [
+    "pillow",
+    "socks"
+  ]
+}
+```
+
+### Recommendation Data (Sheet Schema)
+
+The recommendation logic is a simple mapping of products in the request to recommended companion products. Un-validated identifiers can be any string.
+
+| Request Product ID | Recommended Product |
++--------------------+---------------------+
+|  `[PRODUCT_ID_1]`  |  `[PRODUCT_ID_5]`   |
+|      blanket       |        pillow       |
+|    binoculars      |        ⛺           |
+|         *          |        socks        |
+
+The asterisk (`*`) under "Request Product ID" is a wildcard mapping. If a product is not otherwise mapped to a recommendation, it will default to the wildcard recommendation.
+
+## Deployment
+
+### Setting Up
+
+* Create a new Google Sheet, note the ID of the sheet and the tab.
+* Share the sheet with read-only access to the Cloud Functions service account. For example, `[PROJECT_NAME]@appspot.gserviceaccount.com`. This allows sidestepping most authentication code in the Cloud Function.
+
+### Ship the Code
+
+```
+gcloud functions deploy recommendation \
+  --runtime=nodejs8 \
+  --region=us-central1 \
+  --trigger-http \
+  --set-env-vars=GOOGLE_SHEET_ID=[GOOGLE_SHEET_ID]
+```
+
+### Configuration
+
+* **`GOOGLE_SHEET_ID`**: [required] Unique identifier of the Google Sheet.
+* **`GOOGLE_SHEET_TAB_ID`**: [default=`Recommend`] Name of the worksheet tab from which to pull the data.
+* **`CACHE_TTL_SECONDS`**: [default=`3`] Length of time the sheet data is cached in the function.

--- a/functions/recommendation/index.js
+++ b/functions/recommendation/index.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const {google} = require('googleapis');
+
+// Cache the prepared recommendation lookup table in memory.
+let lookup;
+
+// Impose a lookup TTL.
+let lookup_expire;
+
+exports.recommendation = async (req, res) => {
+  // Uncaught exceptions may lead to an "instance crash", presenting the next
+  // request with a cold start delay.
+  // https://cloud.google.com/functions/docs/monitoring/error-reporting
+  try {
+    if (!lookup || Date.now() > lookup_expire) {
+      // Load the google sheet data.
+      console.log(`Loading Google Sheet '${process.env.GOOGLE_SHEET_ID}'...`);
+      const tab = process.env.GOOGLE_SHEET_TAB_ID || 'Recommend';
+      const sheet = await initSheetData(
+        process.env.GOOGLE_SHEET_ID, `${tab}!A2:B`);
+
+      // Rearrange data into a lookup table.
+      // @todo lookup = buildLookupTableFromSheet(sheet)
+      lookup = buildLookupTableFromRows(sheet);
+      // Add an expiration timestamp for this lookup cache.
+      // @todo move expiration update into build function.
+      const cache_ttl = process.env.CACHE_TTL_SECONDS || 3;
+      lookup_expire = Date.now() + 1000 * cache_ttl;
+      console.log(`Data ready with ${cache_ttl} second TTL`);
+    }
+
+    const recommendation = recommendFromIds(req.query.productId);
+    // Cache for a few minutes to avoid unnecessary function invocations.
+    res.set('Cache-Control', 'public, max-age=3000');
+    res.status(200).send(recommendation);
+  } catch (err) {
+    console.error(`error: building recommendation: ${err}`);
+    res.status(500).send({'error': 'Internal Server Error'});
+  }
+};
+
+// Load data from the Google Sheet.
+const initSheetData = async (spreadsheetId, range) => {
+  const auth = await google.auth.getClient({
+    scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+  });
+  const client = google.sheets({version: 'v4', auth});
+  const response = await client.spreadsheets.values.get({spreadsheetId, range});
+  return response.data.values
+};
+
+// Build the lookup dictionary data structure. e.g., { col0: col1 }
+const buildLookupTableFromRows = (rows) => {
+  if (!rows) {
+    throw new Error('empty sheet data')
+  }
+
+  const table = {}; 
+  rows.forEach((row, index) => {
+    // Marketing will definitely use valid product IDs ALL THE TIME.
+    if (row[0] && row[1]) {
+      table[row[0]] = row[1];
+    } else {
+      console.log(`warning: skipping incomplete mapping on row (${index+1})`);
+    }
+  });
+
+  // Make sure we are able to load a recommendation.
+  if (Object.keys(table).length === 0) {
+    throw new Error(`no valid data found`);
+  }
+
+  return table;
+};
+
+// Create a list of recommendations to complement the provided products.
+const recommendFromIds = (ids) => {
+  // For each product ID from the request,
+  // 1. Check for a specific recommendation
+  // 2. Fall back to a default recommendation
+  // 3. Empty response if neither are available
+  const recommendWithDups = ids.map((id) => lookup[id] || lookup['*'] || '').filter(i => i);
+  // Use the ES6 Set data structure to create a unique set of recommendations.
+  return [...new Set(recommendWithDups)];
+};

--- a/functions/recommendation/package.json
+++ b/functions/recommendation/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "recommendation",
+  "version": "1.0.0",
+  "engines": {
+    "node": ">8.0.0"
+  },
+  "description": "Cloud Function for recommending products based on Google Sheet data.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint *.js",
+    "fix": "eslint *.js --fix"
+  },
+  "keywords": [
+    "google-cloud-functions",
+    "microservice"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "eslint": "^5.14.1",
+    "eslint-config-google": "^0.12.0"
+  },
+  "dependencies": {
+    "googleapis": "^37.2.0"
+  }
+}


### PR DESCRIPTION
Add a manually curated recommendation service. This function provides recommendations hand-mapped via a Google Sheet, demonstrating how Sheets can easily be used as a backoffice administration UI.

See the README for further details.

## Todo

* [ ] Confirmation the architecture fits this repository
* [ ] Address the need for a pre-existing Google Sheet to deploy a functioning function. The initial cloudbuild.yaml change below ignores env vars pending a decision.
* [ ] Determine follow-up vs. blocker on integrating this with the rest of the store.